### PR TITLE
Fixed Inventory Filters

### DIFF
--- a/src/main/java/me/profelements/dynatech/listeners/InventoryFilterListener.java
+++ b/src/main/java/me/profelements/dynatech/listeners/InventoryFilterListener.java
@@ -1,28 +1,24 @@
 package me.profelements.dynatech.listeners;
 
-import io.github.thebusybiscuit.slimefun4.api.player.PlayerBackpack;
 import io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import me.profelements.dynatech.DynaTech;
 import me.profelements.dynatech.items.tools.InventoryFilter;
 import org.bukkit.Material;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityPickupItemEvent;
-import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 import javax.annotation.Nonnull;
-import java.util.ArrayList;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class InventoryFilterListener implements Listener {
-    
+
     private final InventoryFilter inventoryFilter;
-    private final Set<Material> blacklistedMaterials = EnumSet.noneOf(Material.class);
 
     public InventoryFilterListener(@Nonnull DynaTech plugin, @Nonnull InventoryFilter inventoryFilter) {
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
@@ -31,46 +27,32 @@ public class InventoryFilterListener implements Listener {
 
     @EventHandler
     public void onItemPickup(EntityPickupItemEvent e) {
-        if(e.getEntity() instanceof Player) {
-            checkAndFilter((Player) e.getEntity());
+        if (inventoryFilter == null || inventoryFilter.isDisabled()) {
+            return;
         }
-    }
 
-    private void checkAndFilter(Player p) {
-        if (inventoryFilter != null && !inventoryFilter.isDisabled()) {
-            for (ItemStack item : p.getInventory().getContents()) {
-                if (item != null && item.getType() == inventoryFilter.getItem().getType() && item.hasItemMeta() && inventoryFilter.isItem(item)) {
-                    if (SlimefunUtils.canPlayerUseItem(p, item, true)) {
-                        PlayerProfile.getBackpack(item, backpack -> DynaTech.runSync(() -> filterInventory(p, backpack)));
+        if (!(e.getEntity() instanceof Player)) {
+            return;
+        }
+
+        final Player p = (Player) e.getEntity();
+        final Item pickedItem = e.getItem();
+        final ItemStack pickedItemStack = pickedItem.getItemStack();
+
+        for (ItemStack filter : p.getInventory().getContents()) {
+            if (inventoryFilter.isItem(filter) && SlimefunUtils.canPlayerUseItem(p, filter, true)) {
+                PlayerProfile.getBackpack(filter,
+                    backpack -> {
+                    for (ItemStack item : backpack.getInventory().getContents()) {
+                        if (SlimefunUtils.isItemSimilar(item, pickedItemStack, true, false)) {
+                            e.setCancelled(true);
+                            pickedItem.remove();
+                            break;
+                        }
                     }
                 }
+                );
             }
         }
     }
-
-    private void filterInventory(@Nonnull Player p, @Nonnull PlayerBackpack backpack) {
-        List<String> blacklistedStrings = new ArrayList<String>();
-        if (backpack.getInventory().isEmpty()) {
-            blacklistedMaterials.clear();
-            blacklistedStrings.clear();
-        }
-
-        for (ItemStack item : backpack.getInventory().getContents()) {
-            if (item != null && item.getType() != Material.AIR) {
-                //Leaving this here to dont have to deal with checking if its using a default or custom name ie if they are farming custom items like SfItems.
-                blacklistedMaterials.add(item.getType());
-                blacklistedStrings.add(item.getItemMeta().getDisplayName());
-            }
-        }
-
-        //CANT DROP AIR SO HAVE TO ITERATE THROUGH THE INVENTORY
-        Inventory inv = p.getInventory();
-        for (ItemStack item : inv.getStorageContents()) {
-            if (item != null && blacklistedMaterials.contains(item.getType()) && blacklistedStrings.contains(item.getItemMeta().getDisplayName())) {
-                    inv.remove(item);
-                    break;
-            }
-        }
-    }
-    
 }


### PR DESCRIPTION
Inventory Filters were not working correctly: they all shared the same list of names and materials, even across different filters AND different players, and were matching them one at a time - meaning if the correct material and the correct name were somewhere in the filters, EVEN IF COMING FROM TWO DIFFERENT ITEMS, they would still pass the checks (for example, PlayerA having a dirt block and Player B having a renamed stick called "Test" would make every renamed dirt called "Test" pickedby anyone else pass the checks and get yeeted, instead of only vanilla dirt and renamed sticks and once again not respecting the per-player check).